### PR TITLE
feat: Add theme toggle for light/dark mode

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,6 +6,10 @@
 </head>
 <body>
   <h1>To-Do List</h1>
+  <div class="theme-switch-container">
+    <label for="themeToggle">Dark Mode</label>
+    <input type="checkbox" id="themeToggle">
+  </div>
   <input type="text" id="taskInput" placeholder="Enter task...">
   <input type="date" id="taskDateInput">
   <button id="addTaskBtn">Add Task</button>

--- a/script.js
+++ b/script.js
@@ -170,13 +170,60 @@ function renderTasks() {
   });
 }
 
+// --- Theme Switching Logic ---
+// Placed outside DOMContentLoaded for broader scope if needed, but functions
+// manipulating DOM elements like themeToggle will be called within or after DOMContentLoaded.
 
-// Add Task
+function applyTheme(isDark) {
+  if (isDark) {
+    document.body.classList.add('dark-theme');
+  } else {
+    document.body.classList.remove('dark-theme');
+  }
+}
+
+function saveThemePreference(isDark) {
+  localStorage.setItem('themeIsDark', JSON.stringify(isDark));
+}
+
+function loadThemePreference() {
+  const themeToggle = document.getElementById('themeToggle');
+  // Ensure themeToggle exists before trying to use it (it should, if called within DOMContentLoaded)
+  if (!themeToggle) { 
+    console.warn("Theme toggle checkbox not found at loadThemePreference call time.");
+    return; 
+  }
+
+  const storedPreference = localStorage.getItem('themeIsDark');
+  if (storedPreference !== null) {
+    const isDark = JSON.parse(storedPreference);
+    applyTheme(isDark);
+    themeToggle.checked = isDark;
+  } else {
+    // Default to light theme if no preference is stored
+    applyTheme(false);
+    themeToggle.checked = false;
+  }
+}
+
+
+// Add Task & Other Initializations
 document.addEventListener('DOMContentLoaded', () => {
+  const themeToggle = document.getElementById('themeToggle'); // Get reference to the toggle
   const taskInput = document.getElementById('taskInput');
   const taskDateInput = document.getElementById('taskDateInput');
   const addTaskBtn = document.getElementById('addTaskBtn');
 
+  // Theme Toggle Event Listener
+  if (themeToggle) {
+    themeToggle.addEventListener('change', () => {
+      applyTheme(themeToggle.checked);
+      saveThemePreference(themeToggle.checked);
+    });
+  } else {
+    console.warn("Theme toggle checkbox not found during event listener setup.");
+  }
+  
   addTaskBtn.addEventListener('click', () => {
     const text = taskInput.value.trim();
     const dueDate = taskDateInput.value;
@@ -207,12 +254,14 @@ document.addEventListener('DOMContentLoaded', () => {
     }
   });
 
-  loadTasks(); // Load tasks and render them on initial load (uses updated renderTasks)
+  loadTasks(); // Load tasks and render them on initial load
 
   // Calendar State
   let currentCalendarDate = new Date();
-
   renderCalendar(currentCalendarDate.getFullYear(), currentCalendarDate.getMonth());
+
+  // Load theme preference after other initializations
+  loadThemePreference(); 
 });
 
 // --- Calendar Functionality ---

--- a/style.css
+++ b/style.css
@@ -105,6 +105,144 @@ h2 {
   }
 }
 
+/* Dark Theme Styles */
+body.dark-theme {
+  background-color: #121212;
+  color: #e0e0e0;
+}
+
+body.dark-theme .app-container {
+  background-color: #1e1e1e;
+  box-shadow: 0 4px 15px rgba(0, 0, 0, 0.5);
+}
+
+body.dark-theme h1 {
+  color: #ffffff;
+}
+
+body.dark-theme h2 {
+  color: #f0f0f0;
+  border-bottom-color: #333333;
+}
+
+body.dark-theme #taskInput,
+body.dark-theme #taskDateInput {
+  background-color: #2c2c2c;
+  color: #e0e0e0;
+  border-color: #444444;
+}
+
+body.dark-theme #taskInput:focus,
+body.dark-theme #taskDateInput:focus {
+  border-color: #007bff; /* A light blue for focus, stands out in dark mode */
+  box-shadow: 0 0 0 2px rgba(0, 123, 255, 0.25);
+}
+
+body.dark-theme #addTaskBtn {
+  background-color: #007bff;
+  color: #ffffff;
+}
+
+body.dark-theme #addTaskBtn:hover {
+  background-color: #0056b3;
+}
+
+body.dark-theme #taskList li {
+  background-color: #1e1e1e; /* Same as app-container or slightly different if preferred */
+  color: #e0e0e0;
+  border-bottom-color: #333333;
+}
+
+body.dark-theme #taskList li:hover {
+  background-color: #2a2a2a;
+}
+
+body.dark-theme #taskList input[type="checkbox"] {
+  /* May need adjustment if checkbox appearance is poor */
+}
+
+body.dark-theme #taskList li.task-item-completed {
+  background-color: #2a3b2a; /* Darker green for completed tasks */
+  /* color: #a0a0a0; /* Slightly muted text for completed tasks */
+}
+
+body.dark-theme #taskList li.task-item-completed span,
+body.dark-theme #taskList li[style*="text-decoration: line-through"] {
+  color: #888888; /* Ensure strikethrough text is visible */
+}
+
+
+body.dark-theme #taskList li button { /* Delete button */
+  background-color: #c82333; /* Darker red */
+  color: white;
+}
+
+body.dark-theme #taskList li button:hover {
+  background-color: #a51827;
+}
+
+/* Calendar Dark Theme */
+body.dark-theme .calendar-header h3 {
+  color: #f0f0f0;
+}
+
+body.dark-theme .calendar-header button {
+  background-color: #007bff;
+  color: #ffffff;
+}
+
+body.dark-theme .calendar-header button:hover {
+  background-color: #0056b3;
+}
+
+body.dark-theme .calendar-day-label {
+  color: #cccccc; /* Lighter gray for day labels */
+}
+
+body.dark-theme .calendar-day-cell {
+  background-color: #2c2c2c;
+  border-color: #444444;
+  color: #e0e0e0;
+}
+
+body.dark-theme .calendar-day-cell.empty {
+  background-color: #222222;
+  opacity: 0.6;
+}
+
+body.dark-theme .calendar-day-cell:not(.empty):hover {
+  background-color: #383838;
+  box-shadow: 0 0 0 2px rgba(0, 123, 255, 0.25);
+}
+
+body.dark-theme .calendar-day-cell:not(.empty):active {
+   background-color: #404040;
+}
+
+body.dark-theme .calendar-day-cell.has-tasks .calendar-task-indicator {
+  /* The JS adds a span with ' ●', ensure this is visible */
+  /* No specific style needed if the parent's color is inherited and visible */
+}
+body.dark-theme .calendar-day-cell span { /* For the task indicator dot */
+  color: #007bff; /* Make dot blue to stand out */
+}
+
+
+/* Tasks for Date Display Dark Theme */
+body.dark-theme #tasksForDate {
+  background-color: #2c2c2c;
+  border-color: #444444;
+}
+
+body.dark-theme #tasksForDate h4 {
+  color: #f0f0f0;
+}
+
+body.dark-theme #tasksForDate li {
+  border-bottom-color: #444444;
+  color: #e0e0e0;
+}
+
 @keyframes fadeOutSlideUp {
   from {
     opacity: 1;


### PR DESCRIPTION
Implemented a theme toggle feature that allows you to switch between a light and dark theme for the application.

Key changes:
- Added a toggle switch to `index.html`.
- Defined dark theme styles in `style.css` under a `body.dark-theme` class.
- Implemented JavaScript logic in `script.js` to:
    - Apply the selected theme by toggling the `dark-theme` class on the body.
    - Save your theme preference to `localStorage`.
    - Load and apply the saved theme preference on page load.

This enhances your experience by providing visual customization options.